### PR TITLE
fix bug that overwrites pid in vdeliver

### DIFF
--- a/commands/vdeliver.cc
+++ b/commands/vdeliver.cc
@@ -176,7 +176,7 @@ void deliver_partial()
   const mystring hostname = make_hostname();
   pid_t pid = getpid();
   for(;; sleep(2)) {
-    partname = "/" + mystring(itoa(time(0))) + "." + itoa(pid)
+    partname = "/" + mystring(itoa(time(0))) + "." + mystring(itoa(pid))
       + "." + hostname;
     
     mystring newfile = newdir + partname;


### PR DESCRIPTION
This bug has been [reported on the vmailmgr mailing list in 2007](http://lists.untroubled.org/?list=vmailmgr&cmd=showmsg&msgnum=9840): The double use of `itoa()` when constructing the `partname` used for generating the filenames for Maildir delivery currently leads to the situation that in the intended scheme of <timestamp>.<pid>.<hostname> the value of <pid> is _not_ the actual process ID but the last numbers of <timestamp> with the _length_ of the process ID because the memory area in question gets overwritten. This results in vmailmgr being restricted to one delivery per second (to the same Maildir) because two deliveries within the same second generate exactly the same filename.

The correct fix has been [reported on the mailing list in 2012](http://lists.untroubled.org/?list=vmailmgr&cmd=showmsg&msgnum=9950), with kudos to Matija Nalis:

> It is due to lib/misc/itoa.cc:itoa() using static char[] -- so when
> you call itoa() twice in same assignment, one value overwrites other
> before it had a chance to be saved to some unique part of memory
> which won't get overwritten on next call.. Beauty of C ;-)
> 
> So the solution is to change "itoa(pid)" to "mystring(itoa(pid))"
> which will make a copy and hence the problem will be gone...  

I confirm this patch fixes the problem. Please include it in further versions of vmailmgr.
